### PR TITLE
Adjust fetcher for new primary ip pricing format and ignore v6 primary addresses. (fixes #39)

### DIFF
--- a/fetcher/primaryip.go
+++ b/fetcher/primaryip.go
@@ -8,7 +8,7 @@ var _ Fetcher = &floatingIP{}
 
 // NewPrimaryIP creates a new fetcher that will collect pricing information on primary IPs.
 func NewPrimaryIP(pricing *PriceProvider) Fetcher {
-	return &primaryIP{newBase(pricing, "primaryip", "datacenter")}
+	return &primaryIP{newBase(pricing, "primaryip", "location")}
 }
 
 type primaryIP struct {
@@ -24,7 +24,7 @@ func (primaryIP primaryIP) Run(client *hcloud.Client) error {
 	for _, p := range primaryIPs {
 		datacenter := p.Datacenter
 
-		hourlyPrice, monthlyPrice, err := primaryIP.pricing.PrimaryIP(p.Type, datacenter.Name)
+		hourlyPrice, monthlyPrice, err := primaryIP.pricing.PrimaryIP(p.Type, datacenter.Location.Name)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
I have adjusted the the fetcher for the new API format. Please consider this blocked until https://github.com/hetznercloud/hcloud-go/pull/222 is resolved.