### PR TITLE
Add additional labels flag

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -23,9 +23,10 @@ type Fetcher interface {
 }
 
 type baseFetcher struct {
-	pricing *PriceProvider
-	hourly  *prometheus.GaugeVec
-	monthly *prometheus.GaugeVec
+	pricing          *PriceProvider
+	hourly           *prometheus.GaugeVec
+	monthly          *prometheus.GaugeVec
+	additionalLabels []string
 }
 
 func (fetcher baseFetcher) GetHourly() *prometheus.GaugeVec {
@@ -36,8 +37,8 @@ func (fetcher baseFetcher) GetMonthly() *prometheus.GaugeVec {
 	return fetcher.monthly
 }
 
-func newBase(pricing *PriceProvider, resource string, additionalLabels ...string) *baseFetcher {
-	labels := []string{"name"}
+func newBase(pricing *PriceProvider, resource string, baselabels []string, additionalLabels ...string) *baseFetcher {
+	labels := append([]string{"name"}, baselabels...)
 	labels = append(labels, additionalLabels...)
 
 	hourlyGaugeOpts := prometheus.GaugeOpts{
@@ -54,9 +55,10 @@ func newBase(pricing *PriceProvider, resource string, additionalLabels ...string
 	}
 
 	return &baseFetcher{
-		pricing: pricing,
-		hourly:  prometheus.NewGaugeVec(hourlyGaugeOpts, labels),
-		monthly: prometheus.NewGaugeVec(monthlyGaugeOpts, labels),
+		pricing:          pricing,
+		hourly:           prometheus.NewGaugeVec(hourlyGaugeOpts, labels),
+		monthly:          prometheus.NewGaugeVec(monthlyGaugeOpts, labels),
+		additionalLabels: additionalLabels,
 	}
 }
 

--- a/fetcher/floatingip.go
+++ b/fetcher/floatingip.go
@@ -8,13 +8,11 @@ var _ Fetcher = &floatingIP{}
 
 // NewFloatingIP creates a new fetcher that will collect pricing information on floating IPs.
 func NewFloatingIP(pricing *PriceProvider, additionalLabels ...string) Fetcher {
-	labels := append([]string{"location", "type"}, additionalLabels...)
-	return &floatingIP{newBase(pricing, "floatingip", labels...), additionalLabels}
+	return &floatingIP{newBase(pricing, "floatingip", []string{"location", "type"}, additionalLabels...)}
 }
 
 type floatingIP struct {
 	*baseFetcher
-	additionalLabels []string
 }
 
 func (floatingIP floatingIP) Run(client *hcloud.Client) error {

--- a/fetcher/floatingip.go
+++ b/fetcher/floatingip.go
@@ -7,12 +7,14 @@ import (
 var _ Fetcher = &floatingIP{}
 
 // NewFloatingIP creates a new fetcher that will collect pricing information on floating IPs.
-func NewFloatingIP(pricing *PriceProvider) Fetcher {
-	return &floatingIP{newBase(pricing, "floatingip", "location", "type")}
+func NewFloatingIP(pricing *PriceProvider, additionalLabels ...string) Fetcher {
+	labels := append([]string{"location", "type"}, additionalLabels...)
+	return &floatingIP{newBase(pricing, "floatingip", labels...), additionalLabels}
 }
 
 type floatingIP struct {
 	*baseFetcher
+	additionalLabels []string
 }
 
 func (floatingIP floatingIP) Run(client *hcloud.Client) error {
@@ -27,8 +29,16 @@ func (floatingIP floatingIP) Run(client *hcloud.Client) error {
 		monthlyPrice := floatingIP.pricing.FloatingIP(f.Type, location.Name)
 		hourlyPrice := pricingPerHour(monthlyPrice)
 
-		floatingIP.hourly.WithLabelValues(f.Name, location.Name, string(f.Type)).Set(hourlyPrice)
-		floatingIP.monthly.WithLabelValues(f.Name, location.Name, string(f.Type)).Set(monthlyPrice)
+		labels := append([]string{
+			f.Name,
+			location.Name,
+			string(f.Type),
+		},
+			parseAdditionalLabels(floatingIP.additionalLabels, f.Labels)...,
+		)
+
+		floatingIP.hourly.WithLabelValues(labels...).Set(hourlyPrice)
+		floatingIP.monthly.WithLabelValues(labels...).Set(monthlyPrice)
 	}
 
 	return nil

--- a/fetcher/loadbalancer.go
+++ b/fetcher/loadbalancer.go
@@ -10,13 +10,11 @@ var _ Fetcher = &loadBalancer{}
 
 // NewLoadbalancer creates a new fetcher that will collect pricing information on load balancers.
 func NewLoadbalancer(pricing *PriceProvider, additionalLabels ...string) Fetcher {
-	labels := append([]string{"location", "type"}, additionalLabels...)
-	return &loadBalancer{newBase(pricing, "loadbalancer", labels...), additionalLabels}
+	return &loadBalancer{newBase(pricing, "loadbalancer", []string{"location", "type"}, additionalLabels...)}
 }
 
 type loadBalancer struct {
 	*baseFetcher
-	additionalLabels []string
 }
 
 func (loadBalancer loadBalancer) Run(client *hcloud.Client) error {

--- a/fetcher/loadbalancer_traffic.go
+++ b/fetcher/loadbalancer_traffic.go
@@ -9,12 +9,14 @@ import (
 var _ Fetcher = &loadbalancerTraffic{}
 
 // NewLoadbalancerTraffic creates a new fetcher that will collect pricing information on load balancer traffic.
-func NewLoadbalancerTraffic(pricing *PriceProvider) Fetcher {
-	return &loadbalancerTraffic{newBase(pricing, "loadbalancer_traffic", "location", "type")}
+func NewLoadbalancerTraffic(pricing *PriceProvider, additionalLabels ...string) Fetcher {
+	labels := append([]string{"location", "type"}, additionalLabels...)
+	return &loadbalancerTraffic{newBase(pricing, "loadbalancer_traffic", labels...), additionalLabels}
 }
 
 type loadbalancerTraffic struct {
 	*baseFetcher
+	additionalLabels []string
 }
 
 func (loadbalancerTraffic loadbalancerTraffic) Run(client *hcloud.Client) error {
@@ -26,18 +28,26 @@ func (loadbalancerTraffic loadbalancerTraffic) Run(client *hcloud.Client) error 
 	for _, lb := range loadBalancers {
 		location := lb.Location
 
+		labels := append([]string{
+			lb.Name,
+			location.Name,
+			lb.LoadBalancerType.Name,
+		},
+			parseAdditionalLabels(loadbalancerTraffic.additionalLabels, lb.Labels)...,
+		)
+
 		additionalTraffic := int(lb.OutgoingTraffic) - int(lb.IncludedTraffic)
 		if additionalTraffic < 0 {
-			loadbalancerTraffic.hourly.WithLabelValues(lb.Name, location.Name, lb.LoadBalancerType.Name).Set(0)
-			loadbalancerTraffic.monthly.WithLabelValues(lb.Name, location.Name, lb.LoadBalancerType.Name).Set(0)
+			loadbalancerTraffic.hourly.WithLabelValues(labels...).Set(0)
+			loadbalancerTraffic.monthly.WithLabelValues(labels...).Set(0)
 			break
 		}
 
 		monthlyPrice := math.Ceil(float64(additionalTraffic)/sizeTB) * loadbalancerTraffic.pricing.Traffic()
 		hourlyPrice := pricingPerHour(monthlyPrice)
 
-		loadbalancerTraffic.hourly.WithLabelValues(lb.Name, location.Name, lb.LoadBalancerType.Name).Set(hourlyPrice)
-		loadbalancerTraffic.monthly.WithLabelValues(lb.Name, location.Name, lb.LoadBalancerType.Name).Set(monthlyPrice)
+		loadbalancerTraffic.hourly.WithLabelValues(labels...).Set(hourlyPrice)
+		loadbalancerTraffic.monthly.WithLabelValues(labels...).Set(monthlyPrice)
 	}
 
 	return nil

--- a/fetcher/loadbalancer_traffic.go
+++ b/fetcher/loadbalancer_traffic.go
@@ -10,13 +10,11 @@ var _ Fetcher = &loadbalancerTraffic{}
 
 // NewLoadbalancerTraffic creates a new fetcher that will collect pricing information on load balancer traffic.
 func NewLoadbalancerTraffic(pricing *PriceProvider, additionalLabels ...string) Fetcher {
-	labels := append([]string{"location", "type"}, additionalLabels...)
-	return &loadbalancerTraffic{newBase(pricing, "loadbalancer_traffic", labels...), additionalLabels}
+	return &loadbalancerTraffic{newBase(pricing, "loadbalancer_traffic", []string{"location", "type"}, additionalLabels...)}
 }
 
 type loadbalancerTraffic struct {
 	*baseFetcher
-	additionalLabels []string
 }
 
 func (loadbalancerTraffic loadbalancerTraffic) Run(client *hcloud.Client) error {

--- a/fetcher/primaryip.go
+++ b/fetcher/primaryip.go
@@ -7,12 +7,14 @@ import (
 var _ Fetcher = &floatingIP{}
 
 // NewPrimaryIP creates a new fetcher that will collect pricing information on primary IPs.
-func NewPrimaryIP(pricing *PriceProvider) Fetcher {
-	return &primaryIP{newBase(pricing, "primaryip", "datacenter", "type")}
+func NewPrimaryIP(pricing *PriceProvider, additionalLabels ...string) Fetcher {
+	labels := append([]string{"datacenter", "type"}, additionalLabels...)
+	return &primaryIP{newBase(pricing, "primaryip", labels...), additionalLabels}
 }
 
 type primaryIP struct {
 	*baseFetcher
+	additionalLabels []string
 }
 
 func (primaryIP primaryIP) Run(client *hcloud.Client) error {
@@ -29,8 +31,16 @@ func (primaryIP primaryIP) Run(client *hcloud.Client) error {
 			return err
 		}
 
-		primaryIP.hourly.WithLabelValues(p.Name, datacenter.Name, string(p.Type)).Set(hourlyPrice)
-		primaryIP.monthly.WithLabelValues(p.Name, datacenter.Name, string(p.Type)).Set(monthlyPrice)
+		labels := append([]string{
+			p.Name,
+			datacenter.Name,
+			string(p.Type),
+		},
+			parseAdditionalLabels(primaryIP.additionalLabels, p.Labels)...,
+		)
+
+		primaryIP.hourly.WithLabelValues(labels...).Set(hourlyPrice)
+		primaryIP.monthly.WithLabelValues(labels...).Set(monthlyPrice)
 	}
 
 	return nil

--- a/fetcher/primaryip.go
+++ b/fetcher/primaryip.go
@@ -8,13 +8,11 @@ var _ Fetcher = &floatingIP{}
 
 // NewPrimaryIP creates a new fetcher that will collect pricing information on primary IPs.
 func NewPrimaryIP(pricing *PriceProvider, additionalLabels ...string) Fetcher {
-	labels := append([]string{"datacenter", "type"}, additionalLabels...)
-	return &primaryIP{newBase(pricing, "primaryip", labels...), additionalLabels}
+	return &primaryIP{newBase(pricing, "primaryip", []string{"datacenter", "type"}, additionalLabels...)}
 }
 
 type primaryIP struct {
 	*baseFetcher
-	additionalLabels []string
 }
 
 func (primaryIP primaryIP) Run(client *hcloud.Client) error {

--- a/fetcher/server.go
+++ b/fetcher/server.go
@@ -10,13 +10,11 @@ var _ Fetcher = &server{}
 
 // NewServer creates a new fetcher that will collect pricing information on servers.
 func NewServer(pricing *PriceProvider, additionalLabels ...string) Fetcher {
-	labels := append([]string{"location", "type"}, additionalLabels...)
-	return &loadBalancer{newBase(pricing, "server", labels...), additionalLabels}
+	return &loadBalancer{newBase(pricing, "server", []string{"location", "type"}, additionalLabels...)}
 }
 
 type server struct {
 	*baseFetcher
-	additionalLabels []string
 }
 
 func (server server) Run(client *hcloud.Client) error {

--- a/fetcher/server_backups.go
+++ b/fetcher/server_backups.go
@@ -10,13 +10,11 @@ var _ Fetcher = &serverBackup{}
 
 // NewServerBackup creates a new fetcher that will collect pricing information on server backups.
 func NewServerBackup(pricing *PriceProvider, additionalLabels ...string) Fetcher {
-	labels := append([]string{"location", "type"}, additionalLabels...)
-	return &serverBackup{newBase(pricing, "server_backup", labels...), additionalLabels}
+	return &serverBackup{newBase(pricing, "server_backup", []string{"location", "type"}, additionalLabels...)}
 }
 
 type serverBackup struct {
 	*baseFetcher
-	additionalLabels []string
 }
 
 func (serverBackup serverBackup) Run(client *hcloud.Client) error {

--- a/fetcher/server_traffic.go
+++ b/fetcher/server_traffic.go
@@ -9,12 +9,14 @@ import (
 var _ Fetcher = &serverTraffic{}
 
 // NewServerTraffic creates a new fetcher that will collect pricing information on server traffic.
-func NewServerTraffic(pricing *PriceProvider) Fetcher {
-	return &serverTraffic{newBase(pricing, "server_traffic", "location", "type")}
+func NewServerTraffic(pricing *PriceProvider, additionalLabels ...string) Fetcher {
+	labels := append([]string{"location", "type"}, additionalLabels...)
+	return &loadBalancer{newBase(pricing, "server_traffic", labels...), additionalLabels}
 }
 
 type serverTraffic struct {
 	*baseFetcher
+	additionalLabels []string
 }
 
 func (serverTraffic serverTraffic) Run(client *hcloud.Client) error {
@@ -26,18 +28,26 @@ func (serverTraffic serverTraffic) Run(client *hcloud.Client) error {
 	for _, s := range servers {
 		location := s.Datacenter.Location
 
+		labels := append([]string{
+			s.Name,
+			location.Name,
+			s.ServerType.Name,
+		},
+			parseAdditionalLabels(serverTraffic.additionalLabels, s.Labels)...,
+		)
+
 		additionalTraffic := int(s.OutgoingTraffic) - int(s.IncludedTraffic)
 		if additionalTraffic < 0 {
-			serverTraffic.hourly.WithLabelValues(s.Name, location.Name, s.ServerType.Name).Set(0)
-			serverTraffic.monthly.WithLabelValues(s.Name, location.Name, s.ServerType.Name).Set(0)
+			serverTraffic.hourly.WithLabelValues(labels...).Set(0)
+			serverTraffic.monthly.WithLabelValues(labels...).Set(0)
 			break
 		}
 
 		monthlyPrice := math.Ceil(float64(additionalTraffic)/sizeTB) * serverTraffic.pricing.Traffic()
 		hourlyPrice := pricingPerHour(monthlyPrice)
 
-		serverTraffic.hourly.WithLabelValues(s.Name, location.Name, s.ServerType.Name).Set(hourlyPrice)
-		serverTraffic.monthly.WithLabelValues(s.Name, location.Name, s.ServerType.Name).Set(monthlyPrice)
+		serverTraffic.hourly.WithLabelValues(labels...).Set(hourlyPrice)
+		serverTraffic.monthly.WithLabelValues(labels...).Set(monthlyPrice)
 	}
 
 	return nil

--- a/fetcher/server_traffic.go
+++ b/fetcher/server_traffic.go
@@ -10,13 +10,11 @@ var _ Fetcher = &serverTraffic{}
 
 // NewServerTraffic creates a new fetcher that will collect pricing information on server traffic.
 func NewServerTraffic(pricing *PriceProvider, additionalLabels ...string) Fetcher {
-	labels := append([]string{"location", "type"}, additionalLabels...)
-	return &loadBalancer{newBase(pricing, "server_traffic", labels...), additionalLabels}
+	return &loadBalancer{newBase(pricing, "server_traffic", []string{"location", "type"}, additionalLabels...)}
 }
 
 type serverTraffic struct {
 	*baseFetcher
-	additionalLabels []string
 }
 
 func (serverTraffic serverTraffic) Run(client *hcloud.Client) error {

--- a/fetcher/snapshot.go
+++ b/fetcher/snapshot.go
@@ -8,12 +8,11 @@ var _ Fetcher = &snapshot{}
 
 // NewSnapshot creates a new fetcher that will collect pricing information on server snapshots.
 func NewSnapshot(pricing *PriceProvider, additionalLabels ...string) Fetcher {
-	return &snapshot{newBase(pricing, "snapshot", additionalLabels...), additionalLabels}
+	return &snapshot{newBase(pricing, "snapshot", nil, additionalLabels...)}
 }
 
 type snapshot struct {
 	*baseFetcher
-	additionalLabels []string
 }
 
 func (snapshot snapshot) Run(client *hcloud.Client) error {

--- a/fetcher/utils.go
+++ b/fetcher/utils.go
@@ -39,3 +39,17 @@ func parseToGauge(gauge prometheus.Gauge, value string) {
 	}
 	gauge.Set(parsed)
 }
+
+func parseAdditionalLabels(additionalLabels []string, labels map[string]string) (result []string) {
+alLoop:
+	for _, al := range additionalLabels {
+		for k, v := range labels {
+			if k == al {
+				result = append(result, v)
+				continue alLoop
+			}
+		}
+		result = append(result, "")
+	}
+	return result
+}

--- a/fetcher/utils.go
+++ b/fetcher/utils.go
@@ -41,15 +41,17 @@ func parseToGauge(gauge prometheus.Gauge, value string) {
 }
 
 func parseAdditionalLabels(additionalLabels []string, labels map[string]string) (result []string) {
-alLoop:
 	for _, al := range additionalLabels {
-		for k, v := range labels {
-			if k == al {
-				result = append(result, v)
-				continue alLoop
-			}
-		}
-		result = append(result, "")
+		result = append(result, findLabel(labels, al))
 	}
 	return result
+}
+
+func findLabel(labels map[string]string, label string) string {
+	for k, v := range labels {
+		if k == label {
+			return v
+		}
+	}
+	return ""
 }

--- a/fetcher/volume.go
+++ b/fetcher/volume.go
@@ -10,13 +10,11 @@ var _ Fetcher = &volume{}
 
 // NewVolume creates a new fetcher that will collect pricing information on volumes.
 func NewVolume(pricing *PriceProvider, additionalLabels ...string) Fetcher {
-	labels := append([]string{"location", "bytes"}, additionalLabels...)
-	return &volume{newBase(pricing, "volume", labels...), additionalLabels}
+	return &volume{newBase(pricing, "volume", []string{"location", "bytes"}, additionalLabels...)}
 }
 
 type volume struct {
 	*baseFetcher
-	additionalLabels []string
 }
 
 func (volume volume) Run(client *hcloud.Client) error {

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func handleFlags() {
 
 	additionalLabelsFlag = strings.TrimSpace(strings.ReplaceAll(additionalLabelsFlag, " ", ""))
 	additionalLabelsSlice := strings.Split(additionalLabelsFlag, ",")
-	if len(additionalLabelsSlice) > 1 && additionalLabelsSlice[0] != "" {
+	if len(additionalLabelsSlice) > 0 && additionalLabelsSlice[0] != "" {
 		additionalLabels = additionalLabelsSlice
 	}
 }

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -74,6 +75,7 @@ func main() {
 	fetchers.RegisterCollectors(registry)
 
 	http.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+	log.Printf("Listening on: http://0.0.0.0:%d\n", port)
 	if err := http.ListenAndServe(fmt.Sprintf(":%d", port), nil); err != nil {
 		panic(err)
 	}

--- a/main.go
+++ b/main.go
@@ -46,7 +46,10 @@ func handleFlags() {
 	}
 
 	additionalLabelsFlag = strings.TrimSpace(strings.ReplaceAll(additionalLabelsFlag, " ", ""))
-	additionalLabels = strings.Split(additionalLabelsFlag, ",")
+	additionalLabelsSlice := strings.Split(additionalLabelsFlag, ",")
+	if len(additionalLabelsSlice) > 1 && additionalLabelsSlice[0] != "" {
+		additionalLabels = additionalLabelsSlice
+	}
 }
 
 func main() {


### PR DESCRIPTION
In order to add additional parsed tags from each reasource. I've added the flag`-additional-labels`.

The flag takes a comma separated string, which is first parsed as a slice.
Then inserted into each fetcher into a slice.
The slice is later compared to the labels-map for each resource and labels are added with their corresponding value, or as an empty string if not available in resource map.