### PR TITLE
feat: read HCLOUD_TOKEN from file

### DIFF
--- a/helm/hcloud-pricing-exporter/templates/_helpers.tpl
+++ b/helm/hcloud-pricing-exporter/templates/_helpers.tpl
@@ -49,3 +49,15 @@ Selector labels
 app.kubernetes.io/name: {{ include "hcloud-pricing-exporter.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "hcloud-pricing-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "hcloud-pricing-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+

--- a/helm/hcloud-pricing-exporter/templates/deployment.yaml
+++ b/helm/hcloud-pricing-exporter/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       {{- end }}
       labels:
         {{- include "hcloud-pricing-exporter.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -33,6 +36,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "hcloud-pricing-exporter.fullname" . }}
                   key: token
+              {{- else if .Values.secret.file }}
+              value: {{ printf "file:%s" .Values.secret.file }}
               {{- else }}
               valueFrom:
                 secretKeyRef:

--- a/helm/hcloud-pricing-exporter/templates/deployment.yaml
+++ b/helm/hcloud-pricing-exporter/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "hcloud-pricing-exporter.serviceAccountName" . }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm/hcloud-pricing-exporter/templates/role-binding.yaml
+++ b/helm/hcloud-pricing-exporter/templates/role-binding.yaml
@@ -6,8 +6,7 @@ metadata:
   labels:
     {{- include "hcloud-pricing-exporter.labels" . | nindent 4 }}
 subjects:
-  - apiGroup: rbac.authorization.k8s.io
-    kind: ServiceAccount
+  - kind: ServiceAccount
     name: {{ include "hcloud-pricing-exporter.serviceAccountName" . }}
     {{- if eq .Values.rbac.kind "ClusterRole" }}
     namespace: {{ .Release.Namespace }}

--- a/helm/hcloud-pricing-exporter/templates/role-binding.yaml
+++ b/helm/hcloud-pricing-exporter/templates/role-binding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ printf "%sBinding" .Values.rbac.kind }}
+metadata:
+  name: {{ include "hcloud-pricing-exporter.fullname" . }}
+  labels:
+    {{- include "hcloud-pricing-exporter.labels" . | nindent 4 }}
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: ServiceAccount
+    name: {{ include "hcloud-pricing-exporter.serviceAccountName" . }}
+    {{- if eq .Values.rbac.kind "ClusterRole" }}
+    namespace: {{ .Release.Namespace }}
+    {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: {{ .Values.rbac.kind }}
+  name: {{ include "hcloud-pricing-exporter.fullname" . }}
+{{- end }}

--- a/helm/hcloud-pricing-exporter/templates/role.yaml
+++ b/helm/hcloud-pricing-exporter/templates/role.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ .Values.rbac.kind }}
+metadata:
+  name: {{ include "hcloud-pricing-exporter.fullname" . }}
+  labels:
+    {{- include "hcloud-pricing-exporter.labels" . | nindent 4 }}
+{{- with .Values.rbac.rules }}
+rules:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/helm/hcloud-pricing-exporter/templates/serviceaccount.yaml
+++ b/helm/hcloud-pricing-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "hcloud-pricing-exporter.serviceAccountName" . }}
+  labels:
+    {{- include "hcloud-pricing-exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/hcloud-pricing-exporter/values.yaml
+++ b/helm/hcloud-pricing-exporter/values.yaml
@@ -32,7 +32,7 @@ secret:
     key:
   # to read HCLOUD_TOKEN from file, set file to your file path (e.g. /secrets/token)
   # the file must be provided manually (e.g. via secret injection)
-  file: ""
+  file: "/etc/hcloud/token"
 
 serviceMonitor:
   create: false
@@ -47,3 +47,26 @@ nodeSelector: { }
 tolerations: [ ]
 
 affinity: { }
+
+serviceAccount:
+  create: false
+  name: ""
+  annotations: { }
+
+rbac:
+  create: false
+  # can be set to ClusterRole or Role
+  kind: ClusterRole
+  rules: [ ]
+    # - apiGroups:
+    #     - authorization.k8s.io
+    #   resources:
+    #     - subjectaccessreviews
+    #   verbs:
+    #     - create
+    # - apiGroups:
+    #     - authentication.k8s.io
+    #   resources:
+    #     - tokenreviews
+    #   verbs:
+    #     - create

--- a/helm/hcloud-pricing-exporter/values.yaml
+++ b/helm/hcloud-pricing-exporter/values.yaml
@@ -9,6 +9,8 @@ imagePullSecrets: [ ]
 nameOverride: ""
 fullnameOverride: ""
 
+podLabels: { }
+
 podAnnotations: { }
 
 service:
@@ -28,6 +30,9 @@ secret:
   reference:
     name:
     key:
+  # to read HCLOUD_TOKEN from file, set file to your file path (e.g. /secrets/token)
+  # the file must be provided manually (e.g. via secret injection)
+  file: ""
 
 serviceMonitor:
   create: false

--- a/helm/hcloud-pricing-exporter/values.yaml
+++ b/helm/hcloud-pricing-exporter/values.yaml
@@ -32,7 +32,7 @@ secret:
     key:
   # to read HCLOUD_TOKEN from file, set file to your file path (e.g. /secrets/token)
   # the file must be provided manually (e.g. via secret injection)
-  file: "/etc/hcloud/token"
+  file: ""
 
 serviceMonitor:
   create: false

--- a/main.go
+++ b/main.go
@@ -44,6 +44,16 @@ func handleFlags() {
 	if hcloudAPIToken == "" {
 		panic(fmt.Errorf("no API token for HCloud specified, but required"))
 	}
+	if strings.HasPrefix(hcloudAPIToken, "file:") {
+		hcloudAPITokenBytes, err := os.ReadFile(strings.TrimPrefix(hcloudAPIToken, "file:"))
+		if err != nil {
+			panic(fmt.Errorf("failed to read HCLOUD_TOKEN from file: %s", err.Error()))
+		}
+		hcloudAPIToken = strings.TrimSpace(string(hcloudAPITokenBytes))
+	}
+	if len(hcloudAPIToken) != 64 {
+		panic(fmt.Errorf("invalid API token for HCloud specified, must be 64 characters long"))
+	}
 
 	additionalLabelsFlag = strings.TrimSpace(strings.ReplaceAll(additionalLabelsFlag, " ", ""))
 	additionalLabelsSlice := strings.Split(additionalLabelsFlag, ",")


### PR DESCRIPTION
This allows the `HCLOUD_TOKEN` to be read from a file. This can be useful if the token is injected using secret injection (e.g. with the vault agent injector).

I tested the changes on my dev cluster. If someone is interested in using this with the vault agent injector, I used the following helm values:

```yaml
image:
  repository: <custom-image-because-changes-are-not-released>
  tag: <custom-image-because-changes-are-not-released>
secret:
  create: false
  file: /vault/secrets/token
podAnnotations:
  vault.hashicorp.com/agent-inject: "true"
  vault.hashicorp.com/log-format: json
  vault.hashicorp.com/role: <your-vault-role-name>
  vault.hashicorp.com/secret-volume-path-token: /vault/secrets
  vault.hashicorp.com/agent-inject-file-token: token
  vault.hashicorp.com/agent-inject-secret-token: <your-vault-mount>/data/<your-vault-path>
  vault.hashicorp.com/agent-inject-template-token: |
    {{ with secret "<your-vault-mount>/data/<your-vault-path>" -}}
      {{ .Data.data.token }}
    {{- end }}
serviceAccount:
  create: true
rbac:
  create: true
  kind: ClusterRole
  rules:
    - apiGroups:
        - authorization.k8s.io
      resources:
        - subjectaccessreviews
      verbs:
        - create
    - apiGroups:
        - authentication.k8s.io
      resources:
        - tokenreviews
      verbs:
        - create
```

This change is inspired from [external-dns cloudflare provider](https://github.com/kubernetes-sigs/external-dns/blob/master/provider/cloudflare/cloudflare.go#L171). I requested the same change for the hcloud-cloud-controller-manager and hetzner-csi-driver to keep consistency in reading HCLOUD_TOKEN from file.